### PR TITLE
ESLint のバグのため指定していた eslint-disable-line を削除

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,7 @@ rules:
   no-unused-vars:
     - 1
 parserOptions:
+  ecmaVersion: 6
   sourceType: module
 env:
   es6: true

--- a/lib/drivers/base.js
+++ b/lib/drivers/base.js
@@ -1,6 +1,6 @@
 export default class BaseDriver {
   constructor() {
-    if (new.target === BaseDriver) { // eslint-disable-line
+    if (new.target === BaseDriver) {
       throw new TypeError('Cannot instantiate BaseDriver class');
     }
 


### PR DESCRIPTION
ESLint のバグでエラーが出ていたコードに eslint-disable-line を
設定していたものを解除する.

バグはこのプロジェクトの開発中に報告され, eslint/eslint#5420 で修正された.
直接的には estools/escope#101 で修正.
